### PR TITLE
Sync roles to BigQuery

### DIFF
--- a/webAdminStation.py
+++ b/webAdminStation.py
@@ -6,6 +6,7 @@ import sqlite3
 import json
 from accounts import Accounts, Role
 from webBase import WebBase, Cookie
+from webSync import sync_roles
 from cryptography.fernet import Fernet
 from teams import TeamMemberType
 
@@ -168,6 +169,8 @@ class WebAdminStation(WebBase):
                                                "Forgot password request", f"{email} for {user}")
             except sqlite3.IntegrityError:
                 error = "Username already in use"
+        if not error:
+            sync_roles(self.dbConnect)
         return self.users(error)
 
     @cherrypy.expose
@@ -219,6 +222,7 @@ class WebAdminStation(WebBase):
 
         with self.dbConnect() as dbConnection:
             self.engine.accounts.changeRole(dbConnection, barcode, newRole)
+        sync_roles(self.dbConnect)
         raise cherrypy.HTTPRedirect("/admin/users")
 
     @cherrypy.expose

--- a/webSync.py
+++ b/webSync.py
@@ -94,6 +94,27 @@ class WebSync(WebBase):
                 for row in cursor.fetchall()
             ]
 
+    def _load_roles(self):
+        with self.dbConnect() as db:
+            cursor = db.execute(
+                "SELECT barcode, displayName, role & 0x04 AS coach,"
+                "       role & 0x08 AS certifier, role & 0x10 AS keyholder,"
+                "       role & 0x40 AS steward"
+                " FROM accounts"
+                " WHERE role != 0"
+            )
+            return [
+                {
+                    "barcode":    row[0],
+                    "displayName": row[1],
+                    "coach":      bool(row[2]),
+                    "certifier":  bool(row[3]),
+                    "keyholder":  bool(row[4]),
+                    "steward":    bool(row[5]),
+                }
+                for row in cursor.fetchall()
+            ]
+
     def _load_certifications(self):
         with self.dbConnect() as db:
             cursor = db.execute(
@@ -162,6 +183,18 @@ class WebSync(WebBase):
                     bigquery.SchemaField("certifier_id", "STRING"),
                     bigquery.SchemaField("date",         "TIMESTAMP"),
                     bigquery.SchemaField("level",        "INTEGER"),
+                ],
+            ),
+            "roles": self._upload(
+                "roles",
+                self._load_roles(),
+                [
+                    bigquery.SchemaField("barcode",     "STRING"),
+                    bigquery.SchemaField("displayName", "STRING"),
+                    bigquery.SchemaField("coach",       "BOOL"),
+                    bigquery.SchemaField("certifier",   "BOOL"),
+                    bigquery.SchemaField("keyholder",   "BOOL"),
+                    bigquery.SchemaField("steward",     "BOOL"),
                 ],
             ),
         }

--- a/webSync.py
+++ b/webSync.py
@@ -5,6 +5,65 @@ from google.cloud import bigquery
 from google.oauth2 import service_account
 
 
+def _get_bq_client():
+    project = cherrypy.config.get("bigquery.project", "")
+    creds_path = cherrypy.config.get("bigquery.credentials", "")
+    if creds_path:
+        creds = service_account.Credentials.from_service_account_file(
+            creds_path,
+            scopes=["https://www.googleapis.com/auth/bigquery"],
+        )
+        return bigquery.Client(credentials=creds, project=project)
+    return bigquery.Client(project=project)
+
+
+def _upload(table_name, rows, schema):
+    client = _get_bq_client()
+    dataset = cherrypy.config.get("bigquery.dataset", "")
+    table_ref = f"{client.project}.{dataset}.{table_name}"
+    job_config = bigquery.LoadJobConfig(
+        write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+        schema=schema,
+    )
+    job = client.load_table_from_json(rows, table_ref, job_config=job_config)
+    job.result()
+    return len(rows)
+
+
+def sync_roles(db_connect):
+    with db_connect() as db:
+        cursor = db.execute(
+            "SELECT barcode, displayName, role & 0x04 AS coach,"
+            "       role & 0x08 AS certifier, role & 0x10 AS keyholder,"
+            "       role & 0x40 AS steward"
+            " FROM accounts"
+            " WHERE role != 0"
+        )
+        rows = [
+            {
+                "barcode":     row[0],
+                "displayName": row[1],
+                "coach":       bool(row[2]),
+                "certifier":   bool(row[3]),
+                "keyholder":   bool(row[4]),
+                "steward":     bool(row[5]),
+            }
+            for row in cursor.fetchall()
+        ]
+    return _upload(
+        "roles",
+        rows,
+        [
+            bigquery.SchemaField("barcode",     "STRING"),
+            bigquery.SchemaField("displayName", "STRING"),
+            bigquery.SchemaField("coach",       "BOOL"),
+            bigquery.SchemaField("certifier",   "BOOL"),
+            bigquery.SchemaField("keyholder",   "BOOL"),
+            bigquery.SchemaField("steward",     "BOOL"),
+        ],
+    )
+
+
 class WebSync(WebBase):
     def _check_auth(self):
         expected = cherrypy.config.get("sync.token", "")
@@ -13,28 +72,8 @@ class WebSync(WebBase):
             cherrypy.response.headers["WWW-Authenticate"] = 'Bearer realm="sync"'
             raise cherrypy.HTTPError(401, "Unauthorized")
 
-    def _get_bq_client(self):
-        project = cherrypy.config.get("bigquery.project", "")
-        creds_path = cherrypy.config.get("bigquery.credentials", "")
-        if creds_path:
-            creds = service_account.Credentials.from_service_account_file(
-                creds_path,
-                scopes=["https://www.googleapis.com/auth/bigquery"],
-            )
-            return bigquery.Client(credentials=creds, project=project)
-        return bigquery.Client(project=project)
-
     def _upload(self, table_name, rows, schema):
-        client = self._get_bq_client()
-        dataset = cherrypy.config.get("bigquery.dataset", "")
-        table_ref = f"{client.project}.{dataset}.{table_name}"
-        job_config = bigquery.LoadJobConfig(
-            write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
-            schema=schema,
-        )
-        job = client.load_table_from_json(rows, table_ref, job_config=job_config)
-        job.result()
-        return len(rows)
+        return _upload(table_name, rows, schema)
 
     def _json_response(self, rows_uploaded):
         cherrypy.response.headers["Content-Type"] = "application/json"
@@ -90,27 +129,6 @@ class WebSync(WebBase):
                     "time":     row[0].isoformat() if row[0] else None,
                     "location": row[1],
                     "barcode":  row[2],
-                }
-                for row in cursor.fetchall()
-            ]
-
-    def _load_roles(self):
-        with self.dbConnect() as db:
-            cursor = db.execute(
-                "SELECT barcode, displayName, role & 0x04 AS coach,"
-                "       role & 0x08 AS certifier, role & 0x10 AS keyholder,"
-                "       role & 0x40 AS steward"
-                " FROM accounts"
-                " WHERE role != 0"
-            )
-            return [
-                {
-                    "barcode":    row[0],
-                    "displayName": row[1],
-                    "coach":      bool(row[2]),
-                    "certifier":  bool(row[3]),
-                    "keyholder":  bool(row[4]),
-                    "steward":    bool(row[5]),
                 }
                 for row in cursor.fetchall()
             ]
@@ -185,18 +203,7 @@ class WebSync(WebBase):
                     bigquery.SchemaField("level",        "INTEGER"),
                 ],
             ),
-            "roles": self._upload(
-                "roles",
-                self._load_roles(),
-                [
-                    bigquery.SchemaField("barcode",     "STRING"),
-                    bigquery.SchemaField("displayName", "STRING"),
-                    bigquery.SchemaField("coach",       "BOOL"),
-                    bigquery.SchemaField("certifier",   "BOOL"),
-                    bigquery.SchemaField("keyholder",   "BOOL"),
-                    bigquery.SchemaField("steward",     "BOOL"),
-                ],
-            ),
+            "roles": sync_roles(self.dbConnect),
         }
         cherrypy.response.headers["Content-Type"] = "application/json"
         return json.dumps({"status": "ok", "rows_uploaded": results}).encode()


### PR DESCRIPTION
## Summary

- Adds a `roles` table to the BigQuery sync, exporting coach, certifier, keyholder, and steward flags for any account with at least one role set
- Extracts BQ client/upload helpers to module-level functions in `webSync.py` so they can be shared
- Triggers an automatic roles sync after `changeAccess` and `addUser` in the admin UI, keeping BigQuery up to date immediately when roles change

## Test plan

- [ ] Verify full sync (`POST /sync`) includes a `roles` key in the response with the correct row count
- [ ] Change a user's role in the admin UI and confirm the `roles` table in BigQuery reflects the change
- [ ] Add a new user with roles and confirm they appear in BigQuery
- [ ] Confirm existing sync tables (visits, guests, unlocks, certifications) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)