### PR TITLE
Add Bearer-authenticated /sync/members endpoint for CSV bulk upload

### DIFF
--- a/tests/CPtest.py
+++ b/tests/CPtest.py
@@ -13,7 +13,8 @@ class CPTest(helper.CPWebCase):
         testConfig = {
             'global': {
                 'database.path': 'testData/',
-                'database.name': 'test.db'
+                'database.name': 'test.db',
+                'sync.token': 'testtoken',
             }
         }
 

--- a/tests/sync_test.py
+++ b/tests/sync_test.py
@@ -1,0 +1,53 @@
+import json
+
+import CPtest
+
+CSV = (
+    '"First Name","Last Name","TFI Barcode for Button","TFI Barcode AUTO",'
+    '"TFI Barcode AUTONUM","TFI Display Name for Button","Membership End Date"\n'
+    '"Jane","Smith","199001","","199001","Jane S","6/30/2025"\n'
+    '"John","Doe","199002","","199002","John D","6/30/2025"\n'
+)
+
+AUTH = [('Authorization', 'Bearer testtoken')]
+
+
+def _multipart(csv_content):
+    body = (
+        '--x\r\n'
+        'Content-Disposition: form-data; name="csvfile"; filename="members.csv"\r\n'
+        'Content-Type: text/plain\r\n'
+        '\r\n'
+        + csv_content +
+        '\r\n--x--\r\n'
+    )
+    headers = [
+        ('Content-Type', 'multipart/form-data; boundary=x'),
+        ('Content-Length', str(len(body))),
+    ]
+    return headers, body
+
+
+class SyncMembersTest(CPtest.CPTest):
+    def test_upload(self):
+        headers, body = _multipart(CSV)
+        self.getPage('/sync/members', AUTH + headers, 'POST', body)
+        self.assertStatus('200 OK')
+        response = json.loads(self.body)
+        self.assertEqual(response['status'], 'ok')
+        self.assertIn('2', response['message'])  # "Imported 2 from members.csv"
+
+    def test_no_auth(self):
+        headers, body = _multipart(CSV)
+        self.getPage('/sync/members', headers, 'POST', body)
+        self.assertStatus('401 Unauthorized')
+
+    def test_wrong_token(self):
+        headers, body = _multipart(CSV)
+        bad_auth = [('Authorization', 'Bearer wrongtoken')]
+        self.getPage('/sync/members', bad_auth + headers, 'POST', body)
+        self.assertStatus('401 Unauthorized')
+
+    def test_get_not_allowed(self):
+        self.getPage('/sync/members', AUTH, 'GET')
+        self.assertStatus('405 Method Not Allowed')

--- a/webSync.py
+++ b/webSync.py
@@ -76,6 +76,16 @@ class WebSync(WebBase):
         cherrypy.response.headers["Content-Type"] = "application/json"
         return json.dumps({"status": "ok", "rows_uploaded": rows_uploaded}).encode()
 
+    @cherrypy.expose
+    def members(self, csvfile=None):
+        self._require_post()
+        self._check_auth()
+        with self.dbConnect() as dbConnection:
+            result = self.engine.members.bulkAdd(dbConnection, csvfile)
+            self.engine.logEvents.addEvent(dbConnection, "Bulk Add", None)
+        cherrypy.response.headers["Content-Type"] = "application/json"
+        return json.dumps({"status": "ok", "message": result}).encode()
+
     def _require_post(self):
         if cherrypy.request.method != "POST":
             raise cherrypy.HTTPError(405, "Method Not Allowed")


### PR DESCRIPTION
## Summary
- Adds `POST /sync/members` to `WebSync`, accepting a CSV file and Bearer token auth — same pattern as the existing `/sync` endpoint
- Removes the need for an admin session cookie when running automated member imports
- Makes `csvfile=None` so method guard returns 405 (not 404) on non-POST requests
- Adds `sync.token` to shared test config and a new `sync_test.py` covering upload, auth failures, and method guard

## Test plan
- [ ] CI passes on this PR
- [ ] Manual test: `curl -X POST /sync/members -H "Authorization: Bearer <token>" -F "csvfile=@members.csv"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)